### PR TITLE
fix: resolve react-hooks/set-state-in-effect lint errors

### DIFF
--- a/apps/site/src/components/chart/PriceTable.tsx
+++ b/apps/site/src/components/chart/PriceTable.tsx
@@ -1,28 +1,17 @@
 // PriceTable.tsx
 // This component is used to display a price table for a given event.
 import type { PriceData } from "@tixtrend/core";
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 const PriceTable = ({ priceDataSet }: { priceDataSet: PriceData[] }) => {
-  const [eventDataMaxPrice, setEventDataMaxPrice] = useState<number[]>([]);
-  const [eventDataMinPrice, setEventDataMinPrice] = useState<number[]>([]);
-  const [eventDataDate, setEventDataDate] = useState<Date[]>([]);
-
-  useEffect(() => {
+  const { minPrices, maxPrices, dates } = useMemo(() => {
     if (!priceDataSet || priceDataSet.length === 0) {
-      return;
+      return { minPrices: [], maxPrices: [], dates: [] };
     }
-    const minPrices = priceDataSet.map((price) => price.min);
-    const maxPrices = priceDataSet.map((price) => price.max);
-    const dates = priceDataSet.map((price) => new Date(price.timestamp));
-    setEventDataMinPrice(minPrices);
-    setEventDataMaxPrice(maxPrices);
-    setEventDataDate(dates);
-
-    return () => {
-      setEventDataMinPrice([]);
-      setEventDataMaxPrice([]);
-      setEventDataDate([]);
+    return {
+      minPrices: priceDataSet.map((price) => price.min),
+      maxPrices: priceDataSet.map((price) => price.max),
+      dates: priceDataSet.map((price) => new Date(price.timestamp)),
     };
   }, [priceDataSet]);
 
@@ -37,12 +26,12 @@ const PriceTable = ({ priceDataSet }: { priceDataSet: PriceData[] }) => {
           </tr>
         </thead>
         <tbody>
-          {eventDataDate.map((date, index) => {
+          {dates.map((date, index) => {
             return (
               <tr key={date.valueOf()}>
                 <td className="border px-4 py-2">{date.toDateString()}</td>
-                <td className="border px-4 py-2">{eventDataMinPrice[index]}</td>
-                <td className="border px-4 py-2">{eventDataMaxPrice[index]}</td>
+                <td className="border px-4 py-2">{minPrices[index]}</td>
+                <td className="border px-4 py-2">{maxPrices[index]}</td>
               </tr>
             );
           })}

--- a/apps/site/src/components/event/SaveEventButton.tsx
+++ b/apps/site/src/components/event/SaveEventButton.tsx
@@ -3,19 +3,26 @@ import { Button } from "@tixtrend/ui/components/button";
 import { toast } from "@tixtrend/ui/lib/toast";
 import { Heart } from "lucide-react";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
+
+function subscribeToStorage(callback: () => void) {
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
+function getIsSaved(eventId: string): boolean {
+  const savedEvents = JSON.parse(localStorage.getItem("savedEvents") ?? "[]");
+  return savedEvents.some((e: EventData) => e.id === eventId);
+}
 
 const SaveEventButton = ({ event }: { event: EventData }) => {
-  const [saved, setSaved] = useState(false);
+  const saved = useSyncExternalStore(
+    subscribeToStorage,
+    () => getIsSaved(event.id),
+    () => false,
+  );
 
-  useEffect(() => {
-    const savedEvents = JSON.parse(localStorage.getItem("savedEvents") ?? "[]");
-    setSaved(
-      savedEvents.some((savedEvent: EventData) => savedEvent.id === event.id),
-    );
-  }, [event.id]);
-
-  const saveEvent = () => {
+  const saveEvent = useCallback(() => {
     let savedEvents = JSON.parse(localStorage.getItem("savedEvents") ?? "[]");
     if (saved) {
       savedEvents = savedEvents.filter(
@@ -27,11 +34,11 @@ const SaveEventButton = ({ event }: { event: EventData }) => {
       toast.success("Event saved to your list!");
     }
     localStorage.setItem("savedEvents", JSON.stringify(savedEvents));
-    setSaved(!saved);
-  };
+    window.dispatchEvent(new Event("storage"));
+  }, [event, saved]);
 
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
+  const handleClick = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
     saveEvent();
   };
 

--- a/apps/site/src/components/page/PopupNotification.tsx
+++ b/apps/site/src/components/page/PopupNotification.tsx
@@ -1,7 +1,7 @@
 // PopupNotification.tsx
 /* a popup notificaiton which appears in the botttom middle of the screen */
 import type React from "react";
-import { useState, useEffect } from "react";
+import { useRef, useEffect, useCallback } from "react";
 
 const PopupNotification = ({
   isActive,
@@ -13,26 +13,39 @@ const PopupNotification = ({
   children: React.ReactNode;
 }) => {
   const popupDuration = 2000;
-  const [popupOpacity, setPopupOpacity] = useState(0);
+  const elRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  const dismiss = useCallback(() => {
+    if (elRef.current) {
+      elRef.current.style.opacity = "0";
+    }
+    setIsActiveCallback?.(false);
+  }, [setIsActiveCallback]);
 
   useEffect(() => {
     if (isActive) {
-      setPopupOpacity(1);
-      setTimeout(() => {
-        setPopupOpacity(0);
-        setIsActiveCallback?.(false);
-      }, 0.8 * popupDuration);
+      if (elRef.current) {
+        elRef.current.style.opacity = "1";
+      }
+      timerRef.current = setTimeout(dismiss, 0.8 * popupDuration);
     }
-  }, [isActive, setIsActiveCallback]);
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [isActive, dismiss]);
 
   return (
     <>
       {isActive && (
         <div className="absolute right-0 top-0">
           <div
+            ref={elRef}
             className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 transform rounded-lg bg-gray-200 p-4 shadow-lg"
             style={{
-              opacity: popupOpacity,
+              opacity: 0,
               transition: `opacity ${popupDuration * 0.2}ms`,
             }}
           >

--- a/apps/site/src/hooks/useSearchNavigation.ts
+++ b/apps/site/src/hooks/useSearchNavigation.ts
@@ -1,4 +1,4 @@
-import { Route } from "@/app/index";
+import { Route, type SearchParams } from "@/app/index";
 import { useNavigate } from "@tanstack/react-router";
 import { useCallback } from "react";
 
@@ -13,7 +13,7 @@ export function useSearchNavigation() {
   const setPage = useCallback(
     (page: number) => {
       navigate({
-        search: (prev) => ({
+        search: (prev: SearchParams) => ({
           ...prev,
           page,
         }),

--- a/package.json
+++ b/package.json
@@ -21,5 +21,10 @@
     "node": ">=22.0.0",
     "pnpm": ">=9.0.0"
   },
-  "packageManager": "pnpm@9.10.0"
+  "packageManager": "pnpm@9.10.0",
+  "pnpm": {
+    "overrides": {
+      "@smithy/types": "4.8.1"
+    }
+  }
 }

--- a/packages/core/src/modules/events/queue-events-for-polling.ts
+++ b/packages/core/src/modules/events/queue-events-for-polling.ts
@@ -79,10 +79,12 @@ const queueWatchList = async () => {
     );
   }
 
-  const eventIds = Items.map((item) => item.event_id);
+  const eventIds = Items.map(
+    (item: Record<string, unknown>) => item.event_id as string,
+  );
   console.info("watch list eventIds", eventIds);
 
-  const promises = eventIds.map(async (event_id) => {
+  const promises = eventIds.map(async (event_id: string) => {
     return await sendEventToQueue(event_id);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@smithy/types': 4.8.1
+
 importers:
 
   .:
@@ -1624,10 +1627,6 @@ packages:
     resolution: {integrity: sha512-gZU4uAFcdrSi3io8U99Qs/FvVdRxPvIMToi+MFfsy/DN9UqtknJ1ais+2M9yR8e0ASQpNmFYEKeIKVcMjQg3rg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.8.0':
-    resolution: {integrity: sha512-QpELEHLO8SsQVtqP+MkEgCYTFW0pleGozfs3cZ183ZBj9z3VC1CX1/wtFMK64p+5bhtZo41SeLK1rBRtd25nHQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/types@4.8.1':
     resolution: {integrity: sha512-N0Zn0OT1zc+NA+UVfkYqQzviRh5ucWwO7mBV3TmHHprMnfcJNfhlPicDkBHi0ewbh+y3evR6cNAW0Raxvb01NA==}
     engines: {node: '>=18.0.0'}
@@ -2242,7 +2241,7 @@ packages:
   aws-sdk-client-mock-vitest@6.2.1:
     resolution: {integrity: sha512-sFfMbrkkl01dkXkObWm8hfS6JSyKcDc7R+nKf3/cunfP+z4tpg1XQSegjlNk/cu1KeB2BqUFpZY3SnHmi7LWDA==}
     peerDependencies:
-      '@smithy/types': '>=3.5.0'
+      '@smithy/types': 4.8.1
       aws-sdk-client-mock: '>=2.2.0'
 
   aws-sdk-client-mock@4.1.0:
@@ -4561,7 +4560,7 @@ snapshots:
       '@smithy/node-http-handler': 4.4.2
       '@smithy/protocol-http': 5.3.3
       '@smithy/smithy-client': 4.9.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/url-parser': 4.2.3
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -4720,7 +4719,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.3
       '@smithy/signature-v4': 5.3.3
       '@smithy/smithy-client': 4.9.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/util-base64': 4.3.0
       '@smithy/util-middleware': 4.2.3
       '@smithy/util-utf8': 4.2.0
@@ -4848,7 +4847,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.2.3
       '@smithy/property-provider': 4.2.3
       '@smithy/shared-ini-file-loader': 4.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4950,7 +4949,7 @@ snapshots:
       '@aws-sdk/util-dynamodb': 3.917.0(@aws-sdk/client-dynamodb@3.914.0)
       '@smithy/core': 3.17.1
       '@smithy/smithy-client': 4.9.1
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-endpoint-discovery@3.914.0':
@@ -4959,14 +4958,14 @@ snapshots:
       '@aws-sdk/types': 3.914.0
       '@smithy/node-config-provider': 4.3.3
       '@smithy/protocol-http': 5.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.914.0':
     dependencies:
       '@aws-sdk/types': 3.914.0
       '@smithy/protocol-http': 5.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.922.0':
@@ -4979,7 +4978,7 @@ snapshots:
   '@aws-sdk/middleware-logger@3.914.0':
     dependencies:
       '@aws-sdk/types': 3.914.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.922.0':
@@ -4993,7 +4992,7 @@ snapshots:
       '@aws-sdk/types': 3.914.0
       '@aws/lambda-invoke-store': 0.0.1
       '@smithy/protocol-http': 5.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.922.0':
@@ -5020,7 +5019,7 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.914.0
       '@smithy/core': 3.17.0
       '@smithy/protocol-http': 5.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.922.0':
@@ -5123,7 +5122,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.914.0
       '@smithy/config-resolver': 4.4.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.922.0':
@@ -5160,7 +5159,7 @@ snapshots:
 
   '@aws-sdk/types@3.914.0':
     dependencies:
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.922.0':
@@ -5176,7 +5175,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.914.0':
     dependencies:
       '@aws-sdk/types': 3.914.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/url-parser': 4.2.3
       '@smithy/util-endpoints': 3.2.3
       tslib: 2.8.1
@@ -5196,7 +5195,7 @@ snapshots:
   '@aws-sdk/util-user-agent-browser@3.914.0':
     dependencies:
       '@aws-sdk/types': 3.914.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       bowser: 2.12.1
       tslib: 2.8.1
 
@@ -5212,7 +5211,7 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.914.0
       '@aws-sdk/types': 3.914.0
       '@smithy/node-config-provider': 4.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.922.0':
@@ -6004,7 +6003,7 @@ snapshots:
   '@smithy/config-resolver@4.4.0':
     dependencies:
       '@smithy/node-config-provider': 4.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-endpoints': 3.2.3
       '@smithy/util-middleware': 4.2.3
@@ -6023,7 +6022,7 @@ snapshots:
     dependencies:
       '@smithy/middleware-serde': 4.2.3
       '@smithy/protocol-http': 5.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-middleware': 4.2.3
@@ -6078,7 +6077,7 @@ snapshots:
     dependencies:
       '@smithy/protocol-http': 5.3.3
       '@smithy/querystring-builder': 4.2.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/util-base64': 4.3.0
       tslib: 2.8.1
 
@@ -6092,7 +6091,7 @@ snapshots:
 
   '@smithy/hash-node@4.2.3':
     dependencies:
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/util-buffer-from': 4.2.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
@@ -6106,7 +6105,7 @@ snapshots:
 
   '@smithy/invalid-dependency@4.2.3':
     dependencies:
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.4':
@@ -6131,7 +6130,7 @@ snapshots:
   '@smithy/middleware-content-length@4.2.3':
     dependencies:
       '@smithy/protocol-http': 5.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.4':
@@ -6146,7 +6145,7 @@ snapshots:
       '@smithy/middleware-serde': 4.2.3
       '@smithy/node-config-provider': 4.3.3
       '@smithy/shared-ini-file-loader': 4.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/url-parser': 4.2.3
       '@smithy/util-middleware': 4.2.3
       tslib: 2.8.1
@@ -6168,7 +6167,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.3
       '@smithy/service-error-classification': 4.2.3
       '@smithy/smithy-client': 4.9.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/util-middleware': 4.2.3
       '@smithy/util-retry': 4.2.3
       '@smithy/uuid': 1.1.0
@@ -6189,7 +6188,7 @@ snapshots:
   '@smithy/middleware-serde@4.2.3':
     dependencies:
       '@smithy/protocol-http': 5.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.2.4':
@@ -6200,7 +6199,7 @@ snapshots:
 
   '@smithy/middleware-stack@4.2.3':
     dependencies:
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.4':
@@ -6212,7 +6211,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.3
       '@smithy/shared-ini-file-loader': 4.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.4':
@@ -6227,7 +6226,7 @@ snapshots:
       '@smithy/abort-controller': 4.2.3
       '@smithy/protocol-http': 5.3.3
       '@smithy/querystring-builder': 4.2.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.4':
@@ -6250,7 +6249,7 @@ snapshots:
 
   '@smithy/protocol-http@5.3.3':
     dependencies:
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.4':
@@ -6326,7 +6325,7 @@ snapshots:
       '@smithy/middleware-endpoint': 4.3.4
       '@smithy/middleware-stack': 4.2.3
       '@smithy/protocol-http': 5.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       '@smithy/util-stream': 4.5.3
       tslib: 2.8.1
 
@@ -6350,10 +6349,6 @@ snapshots:
       '@smithy/util-stream': 4.5.5
       tslib: 2.8.1
 
-  '@smithy/types@4.8.0':
-    dependencies:
-      tslib: 2.8.1
-
   '@smithy/types@4.8.1':
     dependencies:
       tslib: 2.8.1
@@ -6361,7 +6356,7 @@ snapshots:
   '@smithy/url-parser@4.2.3':
     dependencies:
       '@smithy/querystring-parser': 4.2.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/url-parser@4.2.4':
@@ -6402,7 +6397,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.3
       '@smithy/smithy-client': 4.9.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@4.3.5':
@@ -6419,7 +6414,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.3
       '@smithy/property-provider': 4.2.3
       '@smithy/smithy-client': 4.9.0
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.7':
@@ -6435,7 +6430,7 @@ snapshots:
   '@smithy/util-endpoints@3.2.3':
     dependencies:
       '@smithy/node-config-provider': 4.3.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/util-endpoints@3.2.4':
@@ -6450,7 +6445,7 @@ snapshots:
 
   '@smithy/util-middleware@4.2.3':
     dependencies:
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/util-middleware@4.2.4':
@@ -6461,7 +6456,7 @@ snapshots:
   '@smithy/util-retry@4.2.3':
     dependencies:
       '@smithy/service-error-classification': 4.2.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/util-retry@4.2.4':
@@ -6520,7 +6515,7 @@ snapshots:
   '@smithy/util-waiter@4.2.3':
     dependencies:
       '@smithy/abort-controller': 4.2.3
-      '@smithy/types': 4.8.0
+      '@smithy/types': 4.8.1
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.0':


### PR DESCRIPTION
## Summary
- **PriceTable**: Replace 3x `useState` + `useEffect` with a single `useMemo` to derive `minPrices`, `maxPrices`, and `dates` from `priceDataSet`
- **SaveEventButton**: Replace `useState` + `useEffect` reading localStorage with `useSyncExternalStore` for proper external store subscription and SSR safety
- **PopupNotification**: Replace `useState` for opacity with `useRef` + direct DOM manipulation to avoid setState in useEffect

## Context
`eslint-plugin-react-hooks` v7.0.1 (#534) introduced the `react-hooks/set-state-in-effect` rule, which flags `setState` calls inside `useEffect`. This broke CI for all PRs targeting `develop`.

## Test plan
- [x] `pnpm --filter @tixtrend/site lint` passes with zero warnings
- [ ] Verify site loads without errors
- [ ] Verify price table renders correctly
- [ ] Verify save event button works (add/remove)
- [ ] Verify popup notifications appear and dismiss